### PR TITLE
В расширение seaf-dzo-core внесены специфичные для организации атрибуты:

### DIFF
--- a/entities/changes/requirements.yaml
+++ b/entities/changes/requirements.yaml
@@ -1,0 +1,62 @@
+entities:
+  seaf.change.requirements:
+    schema:
+      type: object
+      patternProperties:
+        "^[a-z0-9_\\$][a-z0-9_\\$]*(\\.[a-z0-9_\\$][a-z0-9_\\$]*)*$":
+#          $ref: "#/$defs/seaf.change.requirements.def"
+          properties:
+            sber:
+              type: object
+              properties:
+                id_sib: # Сбер-специфичное свойство
+                  title: Идентификатор требования SIB
+                  type: string
+                id_sib_previous: #Сбер-специфичное необязательное свойство - код предыдущей версии для требований у которых не изменился текст, но изменился код
+                  title: Идентификатор предыдущей версии для требований у которых не изменился текст но изменился код
+                  type: string
+                standard_version: # Сбер-специфичное свойство
+                  title: Версия стандарта в соответствии с подходом Сбер
+                  type: string
+                applicability_level: # Сбер-специфичное свойство, в котором отражается класс критичности АС, на которые распространяется требование
+                  title: Класс критичности объекта, к которому применяется требование
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - Mission Critical
+                      - Business Critical
+                      - Business Operational
+                      - Office Productivity
+                      - Все
+                obj_und_ctrl:
+                  title: список объектов из справочника объектов архитектурного контроля
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - sber.obj.dc
+                      - sber.obj.network.structure
+                      - sber.obj.network.dc
+                      - sber.obj.network.extnet
+                      - sber.obj.network.transportnet
+                      - sber.obj.network.localnet
+                      - sber.obj.servers
+                      - sber.obj.orchestration
+                      - sber.obj.storage
+                      - sber.obj.backuprestore
+                      - sber.obj.usrworkplace
+                      - sber.obj.monitoring
+                      - sber.obj.informationsystem
+                      - sber.obj.integration
+                      - sber.obj.informationsystem.cn
+                      - sber.obj.informationsystem.reliability
+                      - sber.obj.virtualization
+                      - sber.obj.informationsystem.reliability.stand_in
+                      - sber.obj.informationsystem.reliability.active_active
+                      - sber.obj.informationsystem.reliability.parallel_run
+              required:
+                - id_sib
+                - standard_version
+                - applicability_level
+                - obj_und_ctrl

--- a/entities/changes/requirements.yaml
+++ b/entities/changes/requirements.yaml
@@ -4,7 +4,6 @@ entities:
       type: object
       patternProperties:
         "^[a-z0-9_\\$][a-z0-9_\\$]*(\\.[a-z0-9_\\$][a-z0-9_\\$]*)*$":
-#          $ref: "#/$defs/seaf.change.requirements.def"
           properties:
             sber:
               type: object


### PR DESCRIPTION
1. id_sib - (обязательный)Идентификатор требования SIB
2. id_sib_previous - (необязательный) Идентификатор предыдущей версии для требований у которых не изменился текст но изменился код
3. standard_version - (обязательный) Версия стандарта в соответствии с подходом в организации
4. applicability_level - (обязательный) Класс критичности объекта, к которому применяется требование
5. obj_und_ctrl - (обязательный) список объектов из справочника объектов архитектурного контроля